### PR TITLE
chore: add typescript config

### DIFF
--- a/packages/config/typescript/package.json
+++ b/packages/config/typescript/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@shadcn-webcomponents/typescript-config",
+  "version": "1.0.0",
+  "private": true,
+  "files": [
+    "tsconfig.base.json"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/config/typescript/tsconfig.base.json
+++ b/packages/config/typescript/tsconfig.base.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Base TypeScript Configuration - Shadcn WebComponents",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "isolatedModules": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ESNext",
+    "useDefineForClassFields": false,
+    "verbatimModuleSyntax": true
+  }
+}


### PR DESCRIPTION
Este PR introduz um novo pacote de configuração TypeScript para Shadcn WebComponents. As alterações envolvem a criação de um novo pacote e a definição de um arquivo de configuração TypeScript base.

Criação de novo pacote:

* [`packages/config/typescript/package.json`](diffhunk://#diff-a2123eca1f548835a071933e0ca1aceb16ce3086dbd81e2e336d06f4b4ff666fR1-R11): Adicionada uma nova configuração de pacote para `@shadcn-webcomponents/typescript-config`, incluindo metadados básicos e configurações de publicação.

Configuração básica do TypeScript:

* [`packages/config/typescript/tsconfig.base.json`](diffhunk://#diff-089ec23c60c6c6a93edd59d41d9201705df6f5c7f407c6016e234c111a7aaa58R1-R32): Definiu uma configuração básica abrangente do TypeScript com várias opções do compilador para impor verificação de tipo rigorosa e recursos modernos do JavaScript.